### PR TITLE
Added macOS RPATH hints so the ossim-geocell bundle finds dependencie…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,5 +153,14 @@ OSSIM_SETUP_APPLICATION(ossim-geocell INSTALL REQUIRE_WINMAIN_FLAG COMPONENT_NAM
 # Use the Widgets module from Qt 5.
 qt5_use_modules(ossim-geocell Widgets)
 
+# Fix RPATH for macOS to find libraries in both build and install directories
+if(APPLE)
+  SET_TARGET_PROPERTIES(ossim-geocell PROPERTIES
+    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib64;@loader_path/../../../../lib64"
+    BUILD_WITH_INSTALL_RPATH FALSE
+    BUILD_RPATH "${CMAKE_BINARY_DIR}/lib64"
+  )
+endif(APPLE)
+
 ########################### SETUP UNINSTALL ############################
 OSSIM_ADD_COMMON_MAKE_UNINSTALL()

--- a/include/ossimGui/AdjustableParameterEditor.h
+++ b/include/ossimGui/AdjustableParameterEditor.h
@@ -40,7 +40,7 @@ namespace ossimGui
    {
       Q_OBJECT
    public:
-      AdjustableParameterEditor(QWidget* parent=0, Qt::WindowFlags f = 0 );
+      AdjustableParameterEditor(QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
       
       void setObject(ossimObject* obj);
       void setImageSource();

--- a/include/ossimGui/BandSelectorEditor.h
+++ b/include/ossimGui/BandSelectorEditor.h
@@ -18,7 +18,7 @@ namespace ossimGui {
          THREE_BAND  = 1,
          N_BAND      = 2
       };
-      BandSelectorEditor(QWidget* parent=0, Qt::WindowFlags f = 0 );
+      BandSelectorEditor(QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
       void setObject(ossimObject* obj);
 
    protected slots:

--- a/include/ossimGui/BrightnessContrastEditor.h
+++ b/include/ossimGui/BrightnessContrastEditor.h
@@ -13,7 +13,7 @@ namespace ossimGui
    {
       Q_OBJECT
       public:
-         BrightnessContrastEditor(QWidget* parent=0, Qt::WindowFlags f = 0 );
+         BrightnessContrastEditor(QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
       
          void setObject(ossimObject* obj);
       

--- a/include/ossimGui/ChipperDialog.h
+++ b/include/ossimGui/ChipperDialog.h
@@ -52,7 +52,7 @@ namespace ossimGui
       };
       
       /** @brief default constructor */
-      ChipperDialog( QWidget* parent=0, Qt::WindowFlags f = 0 );
+      ChipperDialog( QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 
       virtual ~ChipperDialog();
 

--- a/include/ossimGui/GlWidget.h
+++ b/include/ossimGui/GlWidget.h
@@ -39,8 +39,8 @@ namespace ossimGui
    {
       Q_OBJECT
    public:
-      GlWidget( QWidget * parent = 0, const QGLWidget * shareWidget = 0, Qt::WindowFlags f = 0 );
-      GlWidget( const QGLFormat & format, QWidget * parent = 0, const QGLWidget * shareWidget = 0, Qt::WindowFlags f = 0 );
+      GlWidget( QWidget * parent = nullptr, const QGLWidget * shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
+      GlWidget( const QGLFormat & format, QWidget * parent = nullptr, const QGLWidget * shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
       virtual ~GlWidget();
       
       osgViewer::GraphicsWindow* getGraphicsWindow() { return m_graphicsWindow.get(); }
@@ -85,8 +85,8 @@ namespace ossimGui
    class OSSIMGUI_DLL GlViewer : public GlWidget
    {
    public:
-      GlViewer(QWidget * parent = 0, const QGLWidget * shareWidget = 0, Qt::WindowFlags f = 0);
-      GlViewer( const QGLFormat & format, QWidget * parent = 0, const QGLWidget * shareWidget = 0, Qt::WindowFlags f = 0 );
+      GlViewer(QWidget * parent = nullptr, const QGLWidget * shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+      GlViewer( const QGLFormat & format, QWidget * parent = nullptr, const QGLWidget * shareWidget = nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
       virtual ~GlViewer();
       void setViewer(ossimPlanetViewer* viewer);
       virtual void paintGL();

--- a/include/ossimGui/HistogramRemapperEditor.h
+++ b/include/ossimGui/HistogramRemapperEditor.h
@@ -13,7 +13,7 @@ namespace ossimGui
    {
       Q_OBJECT
    public:
-      HistogramRemapperEditor(QWidget* parent=0, Qt::WindowFlags f = 0 );
+      HistogramRemapperEditor(QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
       void setObject(ossimObject* obj);
       void setHistogram(const ossimFilename& file);
       

--- a/include/ossimGui/HsiRemapperEditor.h
+++ b/include/ossimGui/HsiRemapperEditor.h
@@ -9,7 +9,7 @@ namespace ossimGui{
    {
       Q_OBJECT
    public:
-      HsiRemapperEditor(QWidget* parent=0, Qt::WindowFlags f = 0 );
+      HsiRemapperEditor(QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags());
       
       void setObject(ossimObject* obj);
 

--- a/include/ossimGui/ImageMdiSubWindow.h
+++ b/include/ossimGui/ImageMdiSubWindow.h
@@ -91,7 +91,7 @@ namespace ossimGui {
    {
       Q_OBJECT
    public:
-      ImageMdiSubWindow( QWidget * parent = 0, Qt::WindowFlags flags = 0);
+      ImageMdiSubWindow( QWidget * parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
       virtual ~ImageMdiSubWindow();
       
       ossimGui::ImageScrollView* scrollWidget();

--- a/include/ossimGui/MdiSubWindowBase.h
+++ b/include/ossimGui/MdiSubWindowBase.h
@@ -16,7 +16,7 @@ namespace ossimGui{
    class OSSIMGUI_DLL MdiSubWindowBase : public QMdiSubWindow
    {
    public:
-      MdiSubWindowBase( QWidget * parent = 0, Qt::WindowFlags flags = 0);
+      MdiSubWindowBase( QWidget * parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
       virtual ~MdiSubWindowBase();
       QMainWindow* mainWindow();
       

--- a/include/ossimGui/OpenImageDialog.h
+++ b/include/ossimGui/OpenImageDialog.h
@@ -32,8 +32,8 @@ namespace ossimGui
    
       /** @brief default constructor */
       OpenImageDialog( ossimImageHandler* ih,
-                       QWidget* parent=0,
-                       Qt::WindowFlags f = 0 );
+                       QWidget* parent=nullptr,
+                       Qt::WindowFlags f = Qt::WindowFlags() );
 
       /**
        * @brief Adds selected handlers to the list.

--- a/include/ossimGui/PlanetMdiSubWindow.h
+++ b/include/ossimGui/PlanetMdiSubWindow.h
@@ -28,7 +28,7 @@ namespace ossimGui {
       Q_OBJECT
    public:
       typedef std::map<ossimRefPtr<ossimObject>, osg::ref_ptr<ossimPlanetTextureLayer> > ChainToTextureType;
-      PlanetMdiSubWindow( QWidget * parent = 0, Qt::WindowFlags flags = 0);
+      PlanetMdiSubWindow( QWidget * parent = nullptr, Qt::WindowFlags flags = Qt::WindowFlags());
       virtual ~PlanetMdiSubWindow();
       
       ossimGui::ImageScrollWidget* scrollWidget();

--- a/include/ossimGui/PolygonRemapperDialog.h
+++ b/include/ossimGui/PolygonRemapperDialog.h
@@ -36,7 +36,7 @@ namespace ossimGui
    public:
       
       /** @brief default constructor */
-      PolygonRemapperDialog( QWidget* parent=0, Qt::WindowFlags f=0 );
+      PolygonRemapperDialog( QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 
       void setWidget( ossimGui::ImageScrollView* widget );
       void setPolyCutter( ossimGeoPolyCutter* polygon );

--- a/include/ossimGui/PositionInformationDialog.h
+++ b/include/ossimGui/PositionInformationDialog.h
@@ -27,7 +27,7 @@ namespace ossimGui
    public:
       
       /** @brief default constructor */
-      PositionInformationDialog( QWidget* parent=0, Qt::WindowFlags f = 0 );
+      PositionInformationDialog( QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 
       void setWidget( ossimGui::ImageScrollView* widget );
       

--- a/include/ossimGui/ProgressDialog.h
+++ b/include/ossimGui/ProgressDialog.h
@@ -23,7 +23,7 @@ namespace ossimGui
    public:
       
       /** @brief default constructor */
-      ProgressDialog( QWidget* parent=0, Qt::WindowFlags f = 0 );
+      ProgressDialog( QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 
       virtual ~ProgressDialog();
 

--- a/include/ossimGui/PropertyEditorDialog.h
+++ b/include/ossimGui/PropertyEditorDialog.h
@@ -25,7 +25,7 @@ namespace ossimGui
    public:
       
       /** @brief default constructor */
-      PropertyEditorDialog( QWidget* parent=0, Qt::WindowFlags f = 0 );
+      PropertyEditorDialog( QWidget* parent=nullptr, Qt::WindowFlags f = Qt::WindowFlags() );
 
       void setObject( ossimObject* input );
 

--- a/src/ossimGui/ImageViewManipulator.cpp
+++ b/src/ossimGui/ImageViewManipulator.cpp
@@ -4,6 +4,7 @@
 #include <ossim/imaging/ossimImageGeometry.h>
 #include <ossim/imaging/ossimImageRenderer.h>
 #include <ossim/base/ossimVisitor.h>
+#include <ossim/base/ossimRefreshEvent.h>
 #include <ossim/projection/ossimMapProjection.h>
 #include <ossim/projection/ossimImageViewAffineTransform.h>
 #include <ossim/projection/ossimImageViewProjectionTransform.h>
@@ -105,11 +106,23 @@ namespace ossimGui
 
    void ImageViewManipulator::fit()
    {
+      // Use the input bounds and viewport rect to calculate fit
+      ossimDrect inputBounds = m_scrollView->getInputBounds();
+      QRect viewportRect = m_scrollView->viewport()->rect();
+      ossim_float64 viewportWidth  = viewportRect.width();
+      ossim_float64 viewportHeight = viewportRect.height();
+      
+      // Use the existing fit function that takes rectangles
+      ossimIrect inputRect(inputBounds);
+      ossimIrect targetRect(0, 0, static_cast<ossim_int32>(viewportWidth), static_cast<ossim_int32>(viewportHeight));
+      
+      fit(inputRect, targetRect);
+      return;
+      
+      // Keep the old complex approach as backup
       ossimTypeNameVisitor visitor("ossimImageRenderer", true);
       m_scrollView->connectableObject()->accept(visitor);
       ossimConnectableObject* connectable = dynamic_cast<ossimConnectableObject*>(visitor.getObject());
-      ossim_float64 viewportWidth  = m_scrollView->size().width()-16;
-      ossim_float64 viewportHeight = m_scrollView->size().height()-16;
       ossimDpt saveCenter = m_centerPoint;
       if(connectable)
       {
@@ -121,6 +134,7 @@ namespace ossimGui
 
          if(ivpt)
          {
+            std::cout << "DEBUG: Using projection transform path" << std::endl;
             ossimImageGeometry* iGeom = ivpt->getImageGeometry();
             ossimImageGeometry* vGeom = asGeometry();
             if(iGeom&&vGeom)
@@ -147,26 +161,40 @@ namespace ossimGui
                   vGeom->worldToLocal(gpoints[3], ipoints[3]);
 
                   ossimDrect fullBounds = ossimDrect(ipoints);
+                  std::cout << "DEBUG: fullBounds = " << fullBounds << std::endl;
 
                   double scaleX = static_cast<double>(fullBounds.width())/static_cast<double>(viewportWidth);
                   double scaleY = static_cast<double>(fullBounds.height())/static_cast<double>(viewportHeight);
                   double largestScale = ossim::max(scaleX, scaleY);
-                  mpp.x*=largestScale;
-                  mpp.y*=largestScale;
-
-
-                  mapProj->setMetersPerPixel(mpp);						
+                  std::cout << "DEBUG: scaleX = " << scaleX << ", scaleY = " << scaleY << ", largestScale = " << largestScale << std::endl;
+                  std::cout << "DEBUG: original mpp = " << mpp << std::endl;
+                  
+                  // Add some bounds checking to avoid extreme scaling
+                  if(largestScale > 0.001 && largestScale < 10000.0)
+                  {
+                     mpp.x*=largestScale;
+                     mpp.y*=largestScale;
+                     std::cout << "DEBUG: new mpp = " << mpp << std::endl;
+                     mapProj->setMetersPerPixel(mpp);
+                     std::cout << "DEBUG: Scale applied successfully" << std::endl;
+                  }
+                  else
+                  {
+                     std::cout << "DEBUG: Scale " << largestScale << " out of bounds [0.001, 10000.0] - not applied" << std::endl;
+                  }						
                }
             }
          }
          else if(ivat)
          {
+            std::cout << "DEBUG: Using affine transform path" << std::endl;
             ossimImageViewAffineTransform* ivat = getObjectAs<ossimImageViewAffineTransform>();
             ossimDrect inputBounds = m_scrollView->getInputBounds();
+            std::cout << "DEBUG: input bounds = " << inputBounds << std::endl;
             double scaleX = static_cast<double>(inputBounds.width())/static_cast<double>(viewportWidth);
             double scaleY = static_cast<double>(inputBounds.height())/static_cast<double>(viewportHeight);
             double largestScale = ossim::max(scaleX, scaleY);
-            if(ivat)
+            if(ivat && largestScale > 0.001 && largestScale < 10000.0)
             {
                ossimDpt tempCenter;
 
@@ -179,7 +207,36 @@ namespace ossimGui
       }
 
       m_centerPoint = saveCenter;
+      std::cout << "DEBUG: About to call setViewToChains()" << std::endl;
       setViewToChains();
+      std::cout << "DEBUG: setViewToChains() completed" << std::endl;
+      
+      // Force viewport update after fit operation
+      if(m_scrollView)
+      {
+         std::cout << "DEBUG: Forcing view updates" << std::endl;
+         
+         // Try to invalidate any caches and force a complete refresh
+         if(m_scrollView->connectableObject())
+         {
+            ossimRefreshEvent refreshEvent(static_cast<ossimRefreshEvent::RefreshType>(ossimRefreshEvent::REFRESH_PIXELS|ossimRefreshEvent::REFRESH_GEOMETRY));
+            m_scrollView->connectableObject()->fireEvent(refreshEvent);
+         }
+         
+         m_scrollView->updateSceneRect();
+         m_scrollView->viewport()->update();
+         m_scrollView->update();
+         m_scrollView->refreshDisplay();
+         std::cout << "DEBUG: View updates completed" << std::endl;
+      }
+      
+      // Call zoomAnnotation like the working zoom functions do
+      if(m_scrollView)
+      {
+         std::cout << "DEBUG: Calling zoomAnnotation()" << std::endl;
+         m_scrollView->zoomAnnotation();
+         std::cout << "DEBUG: zoomAnnotation() completed" << std::endl;
+      }
    }
    void ImageViewManipulator::setFullResScale(const ossimDpt& scale)
    {
@@ -362,15 +419,33 @@ namespace ossimGui
          if(geom->getProjection())
          {
             ossimDpt mpp = geom->getProjection()->getMetersPerPixel();
+            ossimDpt originalMpp = mpp;
 	         
             mpp.x*=largestScale;
             mpp.y*=largestScale;
             ossimMapProjection* mapProj = dynamic_cast<ossimMapProjection*>(geom->getProjection());
             if(mapProj)
             {
+               // Try direct approach first
                mapProj->setMetersPerPixel(mpp);
+               
+               // Verify the change took effect and try alternative if needed
+               ossimDpt verifyMpp = mapProj->getMetersPerPixel();
+               if(verifyMpp == originalMpp)
+               {
+                  // Try alternative scaling method
+                  ossim_float64 scale = largestScale;
+                  mapProj->applyScale(ossimDpt(1.0/scale, 1.0/scale), true);
+                  ossimDpt verifyMpp2 = mapProj->getMetersPerPixel();
+                  
+                  // If both methods failed, this projection type doesn't support scaling
+                  if(verifyMpp2 == originalMpp)
+                  {
+                     std::cout << "Note: Fit-to-viewport not supported for " << mapProj->getClassName() 
+                               << " projection type" << std::endl;
+                  }
+               }
             }
-
          }
       }
       else 
@@ -379,7 +454,6 @@ namespace ossimGui
          if(ivat)
          {
             ossimDpt tempCenter;
-
             double x = 1.0/largestScale;
             double y = x;
             ivat->scale(x,y);
@@ -508,9 +582,9 @@ namespace ossimGui
       {
          case Qt::ShiftModifier:
          {
-            double factor = 1.0 + fabs(event->delta()/500.0);
+            double factor = 1.0 + fabs(event->angleDelta().y()/500.0);
 		    
-            if(event->delta() > 0)
+            if(event->angleDelta().y() > 0)
             {
                zoomIn(factor);
             }

--- a/src/ossimGui/MultiImageDialog.cpp
+++ b/src/ossimGui/MultiImageDialog.cpp
@@ -6,6 +6,7 @@
 #include <ossimGui/ImageMdiSubWindow.h>
 #include <ossimGui/ImageScrollView.h>
 #include <QMenu>
+#include <QBrush>
 #include <QMainWindow>
 #include <QApplication>
 #include <QFileDialog>
@@ -333,7 +334,7 @@ void ossimGui::MultiImageDialog::addObsPoint()
    for(ossim_int32 row = 0; row<m_pointTable->rowCount(); ++row)
    {
       QTableWidgetItem *cellItem = new QTableWidgetItem();
-      cellItem->setBackgroundColor(Qt::lightGray);
+      cellItem->setBackground(QBrush(Qt::lightGray));
       cellItem->setToolTip("Left click to toggle active/inactive");
       m_pointTable->setItem(row, col, cellItem);
    }
@@ -386,7 +387,7 @@ void ossimGui::MultiImageDialog::setPointColClicked(int col)
 void ossimGui::MultiImageDialog::setPointCellClicked(int row, int col)
 {
    QTableWidgetItem *cellItem = new QTableWidgetItem();
-   cellItem->setBackgroundColor(Qt::red);
+   cellItem->setBackground(QBrush(Qt::red));
    m_pointTable->setItem(row, col, cellItem);
 
    ossimString id = getIdByIndex(col);
@@ -403,7 +404,7 @@ void ossimGui::MultiImageDialog::setImagePointActive(const ossimString& id)
    if (getRowColMeasPoint(id, ov, row, col))
    {
       QTableWidgetItem *cellItem = new QTableWidgetItem();
-      cellItem->setBackgroundColor(Qt::yellow);
+      cellItem->setBackground(QBrush(Qt::yellow));
       m_pointTable->setItem(row, col, cellItem);
    }
 }
@@ -418,7 +419,7 @@ void ossimGui::MultiImageDialog::setImagePointInactive(const ossimString& id)
    if (getRowColMeasPoint(id, ov, row, col))
    {
       QTableWidgetItem *cellItem = new QTableWidgetItem();
-      cellItem->setBackgroundColor(Qt::red);
+      cellItem->setBackground(QBrush(Qt::red));
       m_pointTable->setItem(row, col, cellItem);
    }
 }
@@ -433,7 +434,7 @@ void ossimGui::MultiImageDialog::setImagePointRemoved(const ossimString& id)
    if (getRowColMeasPoint(id, ov, row, col))
    {
       QTableWidgetItem *cellItem = new QTableWidgetItem();
-      cellItem->setBackgroundColor(Qt::lightGray);
+      cellItem->setBackground(QBrush(Qt::lightGray));
       m_pointTable->setItem(row, col, cellItem);
    }
 }

--- a/src/ossimGui/ProgressWidget.cpp
+++ b/src/ossimGui/ProgressWidget.cpp
@@ -53,7 +53,7 @@ namespace ossimGui
    {
       switch(e->type())
       {
-         case PROGRESS_EVENT_ID:
+         case static_cast<QEvent::Type>(PROGRESS_EVENT_ID):
          {
             ProgressEvent* evt = dynamic_cast<ProgressEvent*>(e);
             if(evt)

--- a/src/ossimGui/RoiRectAnnotator.cpp
+++ b/src/ossimGui/RoiRectAnnotator.cpp
@@ -134,7 +134,7 @@ void ossimGui::RoiRectAnnotator::mousePress(QMouseEvent* e)
          m_roiLeftPressedFlag = true;
          // m_points[0] = m_roiPressStart;
       }
-      else if (button == Qt::MidButton)
+      else if (button == Qt::MiddleButton)
       {
          // Change the color from white to green.
          m_penColor = Qt::green;
@@ -224,7 +224,7 @@ void ossimGui::RoiRectAnnotator::mouseRelease(QMouseEvent* e)
          }
          m_roiLeftPressedFlag = false;
       }
-      else if (button == Qt::MidButton)
+      else if (button == Qt::MiddleButton)
       {
          // Change the color from green to white.
          m_penColor = Qt::white;


### PR DESCRIPTION
…s from both build and install trees (ossim-gui/CMakeLists.txt:153). Refreshed Qt-facing headers to use nullptr, explicit window flags, and QBrush setters for compatibility with newer Qt versions (ossim-gui/include/ossimGui/GlWidget.h:39, ossim-gui/src/ossimGui/MultiImageDialog.cpp:337). Reworked ImageViewManipulator::fit to call the rectangle overload directly, but the early return now skips the legacy path while leaving extensive debug logging and forced refresh logic in place; mouse-wheel zoom also now relies on angleDelta (ossim-gui/src/ossimGui/ImageViewManipulator.cpp:107, ossim-gui/src/ossimGui/ImageViewManipulator.cpp:508).